### PR TITLE
Update main location.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: GeyserParity
 version: ${project.version}
-main: geyserparity.GeyserParity
+main: com.tbyt.GeyserParity
 api-version: 1.19
 authors: [ TBYT, Camotoy ]
 softdepend: [Geyser-Spigot, floodgate]


### PR DESCRIPTION
Hi,

Tried your plugin, but encounterred this error when the server was starting up :

```
[15:14:07] [Server thread/ERROR]: Could not load 'plugins\GeyserParity.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Cannot find main class `geyserparity.GeyserParity'
	at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:73) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.JavaPluginLoader.loadPlugin(JavaPluginLoader.java:154) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.loadPlugin(SimplePluginManager.java:413) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.loadPlugins(SimplePluginManager.java:321) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R2.CraftServer.loadPlugins(CraftServer.java:436) ~[paper-1.19.3.jar:git-Paper-365]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:273) ~[paper-1.19.3.jar:git-Paper-365]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1101) ~[paper-1.19.3.jar:git-Paper-365]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-365]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.ClassNotFoundException: geyserparity.GeyserParity
	at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:177) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:124) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
	at java.lang.Class.forName0(Native Method) ~[?:?]
	at java.lang.Class.forName(Class.java:467) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:71) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	... 8 more
```

Some search on google pointed to the `plugin.yml` configuration file, more precisely to the `main:` attribute that doesn't point to the proper class.

After manually changing the value inside de jar, the plugin loaded.

So this pull request should fix that issue.

Have a nice day.